### PR TITLE
no longer ignores negative sign on floats

### DIFF
--- a/frb/galaxies/galfit.py
+++ b/frb/galaxies/galfit.py
@@ -298,7 +298,7 @@ def read_fitlog(outfile:str, initfile:str, twocomponent:bool=False)->dict:
                     # TODO: accommodate more complex fits.
                     instance.append((item, pp, lines[kk:kk + 10][pp + 1]))  # and keep the model and error
     # Use regex to identify all floats in fit_out and err_out
-    float_regex = r"\d+\.\d+" # Any string of the form <int>.<int> (which is just a float)
+    float_regex = r"[+-]?\d+\.\d+" # Any string of the form <int>.<int> (which is just a float)
 
     if not twocomponent: # Assumes a single component fit
         # only keep the latest one in case there are multiple runs


### PR DESCRIPTION
@Lachimax, here is the bug fix for the missing negative signs on the floats. 

@profxj, I've updated a regex string that matches floats in the `parse_galfit` function. Until now, the regex matching was ignoring negative signs when looking for floats in the galfit output file. I've gotten away with it as it only affected the PA until now and I don't think we had used that information much. Nevertheless, it might be prudent to re-run `parse_galfit` on all galfit outputs we've generated since Mannings+2020.