### PR TITLE
Fixed name error in average_DMhalos

### DIFF
--- a/frb/dm/igm.py
+++ b/frb/dm/igm.py
@@ -280,7 +280,7 @@ def average_DMhalos(z, cosmo = Planck15, f_hot = 0.75, rmax=1., logMmin=10.3, lo
 
     # Fraction of total mass in halos
     zvals = np.linspace(0, z, 20)
-    fhalos = halos.frac_in_halos(zvals, Mlow = 10**logMmin, Mhigh = 10**logMmax, rmax = rmax)
+    fhalos = frb_hmf.frac_in_halos(zvals, Mlow = 10**logMmin, Mhigh = 10**logMmax, rmax = rmax)
     fhalos_interp = IUS(zvals, fhalos)(zeval)
 
     # Electron number density in halos only


### PR DESCRIPTION
I've identified and fixed an error in the main branch; on line 283 of frb.dm.igm:
    `fhalos = halos.frac_in_halos(zvals, Mlow = 10**logMmin, Mhigh = 10**logMmax, rmax = rmax)`
I've modified this in accordance with the current import statement `from frb.halos import hmf as frb_hmf`
    `fhalos = frb_hmf.frac_in_halos(zvals, Mlow = 10**logMmin, Mhigh = 10**logMmax, rmax = rmax)`
This causes NameError: name 'halos' is not defined when the function is executed.
I suspect this error is left over from when the halos module was structured a little differently.