### PR TITLE
Fix output to file of the DM-redshift grid on first run

### DIFF
--- a/frb/dm/prob_dmz.py
+++ b/frb/dm/prob_dmz.py
@@ -162,7 +162,7 @@ def grab_repo_grid():
 
     # Build?
     if not os.path.isfile(PDM_z_grid_file):
-        build_grid_for_repo()
+        build_grid_for_repo(PDM_z_grid_file)
             
     # Load
     print(f"Loading P(DM,z) grid from {PDM_z_grid_file}")


### PR DESCRIPTION
The commit fixes a missing argument that is necessary for the `frb_pz_dm` script, in particular for the generation of the DM-redshift grid on the first run. No pre-generated grid file is currently provided.