### PR TITLE
Fixing bug models.py

### DIFF
--- a/frb/halos/models.py
+++ b/frb/halos/models.py
@@ -164,7 +164,7 @@ def halo_incidence(Mlow, zFRB, radius=None, hmfe=None, Mhigh=1e16, nsample=20,
     for iz in zs:
         ns.append(hmfe.n_in_bins((Mlow * cosmo.h, Mhigh * cosmo.h), iz) * cosmo.h**3)  # * units.Mpc**-3
     # Interpolate
-    ns = units.Quantity(ns*units.Mpc**-3)
+    ns = units.Quantity(ns*units.Mpc**-3).T
     # Radii
     if radius is None:
         rhoc = cosmo.critical_density(zs)


### PR DESCRIPTION
Transposing ns in halo_incidence to have the same shape as Ap, and sum over a (1, nsamp) shape matrix instead of (nsamp, nsamp) matrix: `ns = units.Quantity(ns*units.Mpc**-3).T`
Other alternative would be to replace 
```
    ns = []
    for iz in zs:
        ns.append(hmfe.n_in_bins((Mlow * cosmo.h, Mhigh * cosmo.h), iz) * cosmo.h**3)  # * units.Mpc**-3
    # Interpolate
    ns = units.Quantity(ns*units.Mpc**-3)
```
by
```
    ns = np.zeros_like(zs)
    for ii,iz in enumerate(zs):
        ns[ii] = hmfe.n_in_bins((Mlow * cosmo.h, Mhigh * cosmo.h), iz) * cosmo.h**3  # * units.Mpc**-3
    # Interpolate
    ns = units.Quantity(ns*units.Mpc**-3)
```