### PR TITLE
DECaLS dr8->dr10

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.9','3.10']
-        deps: [current, numpy122, astropydev, numpydev, astropydev-numpydev]
+        python: ['3.10', '3.11']
+        deps: [current, numpy124, astropydev, numpydev, astropydev-numpydev]
 
     steps:
     - name: Check out repository
@@ -32,10 +32,10 @@ jobs:
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip
-    - name: Test with numpy = 1.22
-      if: "contains(matrix.deps, 'numpy122')"
+    - name: Test with numpy = 1.24
+      if: "contains(matrix.deps, 'numpy124')"
       run: |
-        python -m pip install numpy==1.22
+        python -m pip install numpy==1.24
     - name: Test with dev version of numpy
       if: "contains(matrix.deps, 'numpydev')"
       run: |
@@ -75,7 +75,7 @@ jobs:
     - name: Python codestyle check
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip

--- a/frb/tests/test_frbsurveys.py
+++ b/frb/tests/test_frbsurveys.py
@@ -235,7 +235,7 @@ def test_search_all():
                 'source_id', 'tmass_key', 'WISE_W1', 'WISE_W1_err', 'WISE_W2', 'WISE_W2_err', 'WISE_W3', 'WISE_W3_err', 'WISE_W4', 'WISE_W4_err',
                 'SDSS_ID', 'run', 'rerun', 'camcol', 'SDSS_field', 'type', 'SDSS_u', 'SDSS_g', 'SDSS_r', 'SDSS_i', 'SDSS_z', 'SDSS_u_err', 'SDSS_g_err', 'SDSS_r_err', 'SDSS_i_err', 'SDSS_z_err', 'extinction_u', 'extinction_g', 'extinction_r', 'extinction_i', 'extinction_z', 'photo_z', 'photo_zerr', 'z_spec', 'separation_2',
                 'DELVE_ID', 'ebv', 'DELVE_g', 'DELVE_g_err', 'class_star_g', 'DELVE_r', 'DELVE_r_err', 'class_star_r', 'DELVE_i', 'DELVE_i_err', 'class_star_i', 'DELVE_z', 'DELVE_z_err', 'class_star_z',
-                'DECaL_ID', 'DECaL_brick', 'gaia_pointsource', 'DECaL_g', 'DECaL_r', 'DECaL_z', 'DECaL_g_err', 'DECaL_r_err', 'DECaL_z_err', 'survey', 'z_phot_l68', 'z_phot_median', 'z_phot_u68', 'z_spec_1','z_spec_2',
+                'DECaL_ID', 'DECaL_brick', 'DECaL_type', 'DECaL_g', 'DECaL_r', 'DECaL_z', 'DECaL_g_err', 'DECaL_r_err', 'DECaL_z_err', 'survey', 'z_phot_l68', 'z_phot_median', 'z_phot_u68', 'z_phot_l95', 'z_phot_u95', 'z_spec_1','z_spec_2',
                 'NSC_ID', 'class_star', 'NSC_u', 'NSC_u_err', 'NSC_g', 'NSC_g_err', 'NSC_r', 'NSC_r_err', 'NSC_i', 'NSC_i_err', 'NSC_z', 'NSC_z_err', 'NSC_Y', 'NSC_Y_err', 'NSC_VR', 'NSC_VR_err']
     assert len(setdiff1d(combined_cat.colnames, colnames))==0
     assert combined_cat['Pan-STARRS_ID'][1] == -999.


### PR DESCRIPTION
Migrating from DR8 to DR10 for our DECaLS data. Might potentially break the CHIME_FFFF_PZ PATH code and hence, I'm requesting that @bandersen441 and @lordrick94 take a look.

Most important change is the way stars are defined. Instead of using the `gaia_pointsource` flag which is no longer available in the `tractor` table, I am using the morphological `type` classification. Stars are now `type=='PSF'` in this new system. 