### PR TITLE
Photom err fix

### DIFF
--- a/docs/mags_to_flux.rst
+++ b/docs/mags_to_flux.rst
@@ -1,0 +1,9 @@
+*****************************
+Magnitudes to flux conversion
+*****************************
+
+Most public photometry tables report brightness of objects
+in terms of magnitudes as opposed to flux units (Jy or mJy).
+However, using software such as CIGALE and EAZY are made
+less ambiguous if fluxes are used. To enable this, we provide
+the funciton `frb.surveys.catalog_utils.convert_mags_to_flux`

--- a/docs/mags_to_flux.rst
+++ b/docs/mags_to_flux.rst
@@ -4,6 +4,30 @@ Magnitudes to flux conversion
 
 Most public photometry tables report brightness of objects
 in terms of magnitudes as opposed to flux units (Jy or mJy).
-However, using software such as CIGALE and EAZY are made
-less ambiguous if fluxes are used. To enable this, we provide
-the funciton `frb.surveys.catalog_utils.convert_mags_to_flux`
+However, using software such as CIGALE and EAZY is made
+less ambiguous if fluxes are supplied. To enable this, we provide
+the function `frb.surveys.catalog_utils.convert_mags_to_flux`
+
+The definition for magnitude errors arises from the following
+equation:
+
+.. math::
+  
+  m\pm \delta m = ZP-2.5 \log_{10}(f\pm \delta f) 
+  \Rightarrow m = ZP-2.5 \log_{10}(f)
+  \Rightarrow \delta m = 2.5 \log_{10}(1+\delta f/f)
+
+While the math:`\delta m` formula above is exact, most photometry
+software use a first order Taylor expansion in math:`\delta f/f`
+assuming the error is typically small. i.e. 
+
+.. math::
+  
+  \delta m \approx \frac{2.5}{\log_{10}}(\delta f/f)
+
+This will obviously break down when looking at really faint objects,
+barely at the threshold of detection above the noise floor.
+`convert_mags_to_flux` explicitly assumes the catalog mag errors are
+produced using this approximation. However, if you have reason to believe
+the exact formula was used, you can set `exact_mag_err=True` to get the
+correct flux error.

--- a/frb/tests/test_photom.py
+++ b/frb/tests/test_photom.py
@@ -34,13 +34,13 @@ def test_flux_conversion():
 
     fluxunits = 'mJy'
 
-    fluxtab = convert_mags_to_flux(tab, fluxunits)
+    fluxtab = convert_mags_to_flux(tab, fluxunits, exact_mag_err=False)
 
     # Check fluxes
     assert np.isclose(fluxtab['DES_r'], 0.036307805), "Check AB flux conversion."
 
     # Check errors
-    assert np.isclose(fluxtab['DES_r_err'], 0.02123618797770558), "Check AB flux error."
+    assert np.isclose(fluxtab['DES_r_err'], 0.016720362110466937), "Check AB flux error."
 
 
 def test_fractional_flux():


### PR DESCRIPTION
`convert_mags_to_flux` was previously overestimating flux errors because it assumed an exact formula was used for computing mag errors. Instead, most photometry software uses a first-order approximation. This PR sets that approximation as the default and thus correctly converts mag errors to flux errors.

A toggle is provided to switch to the exact formula if needed.