### PR TITLE
Setting photoz argument default to True

### DIFF
--- a/frb/surveys/panstarrs.py
+++ b/frb/surveys/panstarrs.py
@@ -152,7 +152,7 @@ class Pan_STARRS_Survey(surveycoord.SurveyCoord):
                 user = os.getenv('MAST_CASJOBS_USER')
                 pwd = os.getenv('MAST_CASJOBS_PWD')
                 if user is None or pwd is None:
-                    raise IOError("You need to set the MAST_CASJOBS_USER and MAST_CASJOBS_PWD environment variables. Create an account at https://mastweb.stsci.edu/mcasjobs/CreateAccount.aspx to get your credentials.")
+                    raise IOError("You need to set the MAST_CASJOBS_USER and MAST_CASJOBS_PWD environment variables. Create an account at https://mastweb.stsci.edu/mcasjobs/CreateAccount.aspx to get your credentials. Or set photoz=False in get_catalog.")
                 job = mcj.MastCasJobs(context="HLSP_PS1_STRM", username=user, password=pwd)
                 photoz_tab = job.quick(photoz_query, task_name="Photo-z cone search")
                 photoz_tab.rename_column('objID', 'Pan-STARRS_ID')

--- a/frb/surveys/panstarrs.py
+++ b/frb/surveys/panstarrs.py
@@ -65,7 +65,7 @@ class Pan_STARRS_Survey(surveycoord.SurveyCoord):
     
     def get_catalog(self,query_fields=None,release="dr2",
                     table="stack",print_query=False,
-                    use_psf=False, photoz=False):
+                    use_psf=False, photoz=True):
         """
         Query a catalog in the MAST Pan-STARRS database for
         photometry.


### PR DESCRIPTION
Automatically pulls photo-zs for PS1 and adds them to the PATH candidates table. 

Note that this **REQUIRES** a MAST user account: https://mastweb.stsci.edu/mcasjobs/CreateAccount.aspx
And for MAST_CASJOBS_USER and MAST_CASJOBS_PWD environment variables to be set. 

