### PR TITLE
Cigale fixes

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -77,7 +77,7 @@ The following are required to run some of the halo codes:
 The following are required to build host galaxy objects:
 
 * `pPXF <https://pypi.org/project/ppxf/>`_ version 6.7 or greater
-* `pcigale <https://cigale.lam.fr/>`_ version 2018.0.1 to 2020.0 (cannot yet accommodate 2022.0 or greater)
+* `pcigale <https://cigale.lam.fr/>`_ version 2025.0
 
 The following is required to run the code in dm_kde:
 

--- a/frb/data/analysis/CIGALE/DEIMOS_I.dat
+++ b/frb/data/analysis/CIGALE/DEIMOS_I.dat
@@ -1,4 +1,5 @@
 #DEIMOS_I
+#photon
 #DEIMOS I band https://www2.keck.hawaii.edu/inst/deimos/filter_list.html
 6900.0 0.0
 6900.32 8.49913e-06

--- a/frb/data/analysis/CIGALE/DEIMOS_V.dat
+++ b/frb/data/analysis/CIGALE/DEIMOS_V.dat
@@ -1,4 +1,5 @@
 #DEIMOS_V
+#photon
 #DEIMOS V band https://www2.keck.hawaii.edu/inst/deimos/filter_list.html
 3900.0 0.0
 3901.554307841018 0.0011227459022484

--- a/frb/data/analysis/CIGALE/DEIMOS_Z.dat
+++ b/frb/data/analysis/CIGALE/DEIMOS_Z.dat
@@ -1,4 +1,5 @@
 #DEIMOS_Z
+#photon
 #DEIMOS Z band https://www2.keck.hawaii.edu/inst/deimos/filter_list.html
 7953.19 0.00671759
 7953.8 0.00677755

--- a/frb/data/analysis/CIGALE/DEIMOS_r.dat
+++ b/frb/data/analysis/CIGALE/DEIMOS_r.dat
@@ -1,4 +1,5 @@
 #DEIMOS_r
+#photon
 #DEIMOS r band https://www2.keck.hawaii.edu/inst/deimos/filter_list.html
 5500.0 0.0
 5500.3 0.000159287

--- a/frb/galaxies/cigale.py
+++ b/frb/galaxies/cigale.py
@@ -5,7 +5,7 @@ script. Requires pcigale already installed on the system.
 """
 
 import numpy as np
-import os, multiprocessing
+import os
 from pathlib import Path
 
 from astropy.table import Table
@@ -274,7 +274,7 @@ def _initialise(data_file, config_file="pcigale.ini",
     cigconf.config['sed_modules'] = sed_modules
     cigconf.config['analysis_method'] = 'pdf_analysis'
     if cores is None:
-        cores = multiprocessing.cpu_count() #Use all cores
+        cores = os.cpu_count() #Use all cores
     cigconf.config['cores'] = cores
     cigconf.generate_conf() #Writes defaults to config_file
     cigconf.config['analysis_params']['variables'] = variables
@@ -367,7 +367,7 @@ def run(photometry_table, zcol,
             try:
                 from pcigale_plots.plot_types.sed import SED
             except ImportError:
-                console.print(f"{ERROR} This wrapper is compatible with CIGALE v. 2022 and later. Please update your version.")
+                console.print(f"{ERROR} This wrapper is compatible with CIGALE v. 2025. and later. Please update your version.")
                 pass
 
             # TODO: Let the user customize the plot.

--- a/frb/galaxies/frbgalaxy.py
+++ b/frb/galaxies/frbgalaxy.py
@@ -348,7 +348,7 @@ class FRBGalaxy(object):
             self.photom['EBV'] = EBV
     
     def run_cigale(self, data_file="cigale_in.fits", config_file="pcigale.ini",
-        wait_for_input=False, plot=True, outdir='out', compare_obs_model=False, **kwargs):
+        wait_for_input=False, save_sed=True, plot=True, outdir='out',**kwargs):
         """
         Generates the input data file for CIGALE
         given the photometric points and redshift
@@ -364,6 +364,8 @@ class FRBGalaxy(object):
             wait_for_input (bool, optional):
                 If true, waits for the user to finish editing the auto-generated config file
                 before running.
+            save_sed (bool, optional):
+                Saves the best fit SED if true
             plot (bool, optional):
                 Plots the best fit SED if true
             cores (int, optional):
@@ -372,9 +374,6 @@ class FRBGalaxy(object):
             outdir (str, optional):
                 Path to the many outputs of CIGALE
                 If not supplied, the outputs will appear in a folder named out/
-            compare_obs_model (bool, optional):
-                If True compare the input observed fluxes with the model fluxes
-                This writes a Table to outdir named 'photo_observed_model.dat'
 
         kwargs:  These are passed into gen_cigale_in() and _initialise()
             sed_modules (list of 'str', optional):
@@ -401,8 +400,15 @@ class FRBGalaxy(object):
             new_photom['ID'] = 'FRBGalaxy'
 
 
-        run(new_photom, 'redshift', data_file, config_file,
-        wait_for_input, plot, outdir, compare_obs_model, **kwargs)
+        run(photometry_table = new_photom,
+            zcol = 'redshift',
+            data_file = data_file,
+            config_file = config_file,
+            wait_for_input = wait_for_input,
+            save_sed = save_sed,
+            plot = plot,
+            outdir = outdir,
+            **kwargs)
         return
 
     def get_metaspec(self, instr=None, return_all=False, specdb_file=None):

--- a/frb/surveys/survey_utils.py
+++ b/frb/surveys/survey_utils.py
@@ -20,7 +20,7 @@ from astropy.coordinates import SkyCoord
 from astropy import units as u
 from astropy.table import Table
 from pyvo.dal import DALServiceError
-from requests import ReadTimeout
+from requests import ReadTimeout, HTTPError
 
 import numpy as np
 import warnings


### PR DESCRIPTION
This PR is to update the CIGALE wrapper and to make it compatible with the code in the master branch of CIGALE (v. 2025.0) . Key changes: 
1. Photometry filter names are updated.
2. Module parameters are now compatible with the latest version.
3. Warning and error messages using the same API as CIGALE.
4. Removes the  `compare_obs_model` code chunk as CIGALE is already generating those data. No need for another output table.